### PR TITLE
fix: enhance Cursor and Qoder detection in SSH and DevContainer environments

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -19,6 +19,11 @@ const envConfigs: [string, string][] = [
   ['__CFBundleIdentifier=dev.kiro.desktop', 'Kiro <noreply@kiro.dev>'],
   ['VSCODE_BRAND=Qoder', 'Qoder <noreply@qoder.com>'],
   ['__CFBundleIdentifier=com.qoder.ide', 'Qoder <noreply@qoder.com>'], // Use this unstable variable until Qoder has a better one
+  // Check env variables for IDEs in remove development environments
+  ['VSCODE_GIT_ASKPASS_MAIN=*.cursor-server*', 'Cursor <noreply@cursor.com>'],
+  ['BROWSER=*.cursor-server*', 'Cursor <noreply@cursor.com>'],
+  ['VSCODE_GIT_ASKPASS_MAIN=*.qoder-server*', 'Qoder <noreply@qoder.com>'],
+  ['BROWSER=*.qoder-server*', 'Qoder <noreply@qoder.com>'],
 ];
 
 /**
@@ -300,6 +305,21 @@ function getCoDevelopedBy(): string {
         return coDevelopedBy;
       }
       // Continue to next configuration if value is falsy
+      continue;
+    }
+
+    // For pattern matching cases (starts and ends with *, e.g., "*.cursor-server*")
+    if (
+      expectedValue &&
+      expectedValue.startsWith('*') &&
+      expectedValue.endsWith('*') &&
+      expectedValue.length > 2
+    ) {
+      // Extract the pattern between the asterisks
+      const pattern = expectedValue.substring(1, expectedValue.length - 1);
+      if (actualValue.includes(pattern)) {
+        return coDevelopedBy;
+      }
       continue;
     }
   }

--- a/test/commands/exec.test.ts
+++ b/test/commands/exec.test.ts
@@ -737,6 +737,33 @@ describe('exec command utilities', () => {
       process.env.CLAUDECODE = '';
       expect(getCoDevelopedBy()).toBe('');
     });
+
+    // Enhanced tests for Cursor and Qoder detection
+    it('should return Cursor CoDevelopedBy when VSCODE_GIT_ASKPASS_MAIN contains .cursor-server', () => {
+      clearCoDevelopedByEnvVars();
+      process.env.VSCODE_GIT_ASKPASS_MAIN =
+        '/home/user/.cursor-server/bin/askpass-main.js';
+      expect(getCoDevelopedBy()).toBe('Cursor <noreply@cursor.com>');
+    });
+
+    it('should return Cursor CoDevelopedBy when BROWSER contains .cursor-server', () => {
+      clearCoDevelopedByEnvVars();
+      process.env.BROWSER = '/home/user/.cursor-server/bin/helpers/browser.sh';
+      expect(getCoDevelopedBy()).toBe('Cursor <noreply@cursor.com>');
+    });
+
+    it('should return Qoder CoDevelopedBy when VSCODE_GIT_ASKPASS_MAIN contains .qoder-server', () => {
+      clearCoDevelopedByEnvVars();
+      process.env.VSCODE_GIT_ASKPASS_MAIN =
+        '/home/user/.qoder-server/bin/askpass-main.js';
+      expect(getCoDevelopedBy()).toBe('Qoder <noreply@qoder.com>');
+    });
+
+    it('should return Qoder CoDevelopedBy when BROWSER contains .qoder-server', () => {
+      clearCoDevelopedByEnvVars();
+      process.env.BROWSER = '/home/user/.qoder-server/bin/helpers/browser.sh';
+      expect(getCoDevelopedBy()).toBe('Qoder <noreply@qoder.com>');
+    });
   });
 
   describe('hasCoDevelopedBy', () => {


### PR DESCRIPTION
This commit improves the detection logic for Cursor and Qoder IDEs by adding
pattern matching for environment variables VSCODE_GIT_ASKPASS_MAIN and BROWSER
that contain '.cursor-server' or '.qoder-server' substrings. This fixes issues
where the IDE detection was not working properly in SSH and DevContainer environments.

The changes include:
1. Added new environment variable patterns in envConfigs for Cursor and Qoder detection
2. Enhanced getCoDevelopedBy function to support substring pattern matching
3. Added comprehensive tests to verify the new detection logic

This ensures that users working in remote development environments (SSH, DevContainer)
will have proper Co-developed-by trailers added to their commits when using Cursor or Qoder.

Change-Id: Ieb98755b1c0aa178b49484b2cdc613c11f90df39
Co-developed-by: Qoder <noreply@qoder.com>